### PR TITLE
Fix repository link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # 🎙️ NoteAI-ChromeExtension
 
-[![Version](https://img.shields.io/badge/version-1.0.0-blue.svg)](https://github.com/VictorGHaddad/audio-transcriber/releases/tag/v1.0.0)
+[![Version](https://img.shields.io/badge/version-1.0.0-blue.svg)](https://github.com/VictorGHaddad/NoteAI-ChromeExtension.git/releases/tag/v1.0.0)
 [![License](https://img.shields.io/badge/license-MIT-green.svg)](LICENSE)
 
 Um monorepo completo para transcrição de áudio usando IA, com extensão Chrome, backend FastAPI e dashboard React.
@@ -46,8 +46,8 @@ audio-transcriber/
 
 1. **Clone e acesse o projeto:**
    ```bash
-   git clone https://github.com/VictorGHaddad/audio-transcriber.git
-   cd audio-transcriber
+   git clone https://github.com/VictorGHaddad/NoteAI-ChromeExtension.git.git
+   cd NoteAI-ChromeExtension
    ```
 
 2. **Configure as variáveis de ambiente:**


### PR DESCRIPTION
This pull request updates project references in the documentation to reflect the new repository name, ensuring consistency for users and contributors.

Documentation updates:

* Updated the project version badge link in the main `README.md` to point to the new repository URL.
* Changed the clone instructions in `audio-transcriber/README.md` to use the new repository name and URL.