### PR TITLE
Rename ZIP file for Chrome extension installation

### DIFF
--- a/CHROME-EXTENSION-INSTALL.md
+++ b/CHROME-EXTENSION-INSTALL.md
@@ -43,7 +43,7 @@ Antes de instalar, configure a URL da API:
 ### Criar o ZIP:
 ```bash
 cd audio-transcriber
-zip -r audio-transcriber-extension.zip extension/
+zip -r NoteAI-ChromeExtension.zip extension/
 ```
 
 ### Instalar:
@@ -58,7 +58,7 @@ Se o backend está em um servidor remoto:
 
 ```bash
 # Download via SCP
-scp -r user@YOUR_SERVER_IP:/path/to/extension ./audio-transcriber-extension
+scp -r user@YOUR_SERVER_IP:/path/to/extension ./NoteAI-ChromeExtension
 
 # Ou criar um servidor HTTP temporário no servidor:
 # No servidor:


### PR DESCRIPTION
This pull request updates the installation instructions for the Chrome extension to reflect a new naming convention. The ZIP file and directory references have been renamed from `audio-transcriber-extension` to `NoteAI-ChromeExtension` to ensure consistency with the updated project name.

Documentation updates:

* Renamed the output ZIP file in the extension packaging step from `audio-transcriber-extension.zip` to `NoteAI-ChromeExtension.zip` in `CHROME-EXTENSION-INSTALL.md`.
* Updated SCP command instructions to use `NoteAI-ChromeExtension` instead of `audio-transcriber-extension` in `CHROME-EXTENSION-INSTALL.md`.